### PR TITLE
fix: avoid retrying callable backends on TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevent the `callable` provider from retrying a backend when the backend
+  itself raises `TypeError`, preserving the original exception and avoiding
+  duplicate side effects.
+
 ### Added
 - Open-source readiness scaffolding:
   - `NOTICE`, `CONTRIBUTING.md` (CLA), `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CODEOWNERS`

--- a/src/llm_bridge/providers/callable_provider.py
+++ b/src/llm_bridge/providers/callable_provider.py
@@ -17,14 +17,36 @@ Example:
 
 from __future__ import annotations
 
+import inspect
 import time
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from llm_bridge.base import LLMClient, LLMResponse, Message
 
 
 def _estimate_tokens(text: str) -> int:
     return max(1, len(text.split()) * 4 // 3)
+
+
+def _get_signature(fn: Callable[..., Any]) -> Optional[inspect.Signature]:
+    """Return the callable signature when Python can introspect it."""
+    try:
+        return inspect.signature(fn)
+    except (TypeError, ValueError):
+        return None
+
+
+def _can_bind(
+    signature: inspect.Signature,
+    *args: Any,
+    **kwargs: Any,
+) -> bool:
+    """Check argument compatibility without executing the callable."""
+    try:
+        signature.bind(*args, **kwargs)
+    except TypeError:
+        return False
+    return True
 
 
 class CallableClient(LLMClient):
@@ -44,6 +66,7 @@ class CallableClient(LLMClient):
         if not callable(fn):
             raise TypeError("CallableClient requires a callable `fn`.")
         self._fn = fn
+        self._signature = _get_signature(fn)
         self._model = model
 
     @property
@@ -63,15 +86,28 @@ class CallableClient(LLMClient):
         **kwargs: Any,
     ) -> LLMResponse:
         start = time.perf_counter() * 1000
-        try:
+        signature = self._signature
+        if signature is None or _can_bind(
+            signature,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        ):
             out = self._fn(
                 messages=messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 **kwargs,
             )
-        except TypeError:
+        elif _can_bind(signature, messages):
             out = self._fn(messages)
+        else:
+            raise TypeError(
+                "CallableClient backend must accept either "
+                "(messages, temperature=..., max_tokens=..., **kwargs) "
+                "or (messages)."
+            )
         latency = time.perf_counter() * 1000 - start
 
         if isinstance(out, LLMResponse):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -33,9 +33,41 @@ def test_callable_returns_str():
     assert llm.provider == "callable"
 
 
-def test_callable_two_arg_signature():
+def test_callable_messages_only_signature():
     llm = CallableClient(lambda messages: "two")
     assert llm.complete("x").content == "two"
+
+
+def test_callable_internal_type_error_is_not_retried():
+    calls = 0
+
+    def backend(messages, temperature=0.7, max_tokens=1024, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise TypeError("backend failure")
+
+    llm = CallableClient(backend)
+
+    with pytest.raises(TypeError, match="backend failure"):
+        llm.complete("x")
+
+    assert calls == 1
+
+
+def test_callable_rejects_unsupported_signature_without_execution():
+    calls = 0
+
+    def backend(messages, required):
+        nonlocal calls
+        calls += 1
+        return "unreachable"
+
+    llm = CallableClient(backend)
+
+    with pytest.raises(TypeError, match="must accept either"):
+        llm.complete("x")
+
+    assert calls == 0
 
 
 def test_callable_llmresponse_passthrough():


### PR DESCRIPTION
## Description

Prevents `CallableClient` from retrying a backend when the backend itself
raises `TypeError`.

The previous implementation used a broad `except TypeError` to fall back from
the full keyword call to the minimal `(messages)` signature. That also caught
errors raised inside the backend, causing a second invocation, duplicate side
effects, and loss of the original failure context.

The client now inspects and binds the callable signature before invocation. It
keeps support for both documented callable forms while ensuring the backend is
executed at most once per request. Unsupported signatures are rejected before
execution.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only


## Checklist

- [x] CLA signed when prompted by CLA Assistant
- [x] Commit follows Conventional Commits
- [x] Tests added for the fixed behavior
- [x] Changelog updated
- [x] No secrets, credentials, internal URLs, or proprietary content included
